### PR TITLE
Restrict usage of /wea

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,6 +12,7 @@ commands:
     description: (FAWE) Bypass WorldEdit processing and area restrictions
     aliases: [weanywhere,worldeditanywhere,/wea,/weanywhere,/worldeditanywhere]
     usage: "Vault is required for the toggle. Optionally, you can set the permission fawe.bypass"
+    permission: fawe.admin
   fixlighting:
     description: (FAWE) Fix the lighting in your current chunk
     aliases: [/fixlighting]


### PR DESCRIPTION
Although you could do a check programmatically I prefer using plugin.yml. Your choice, but it seems /wea is not properly restricted.