### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/core/src/main/java/com/boydti/fawe/FaweAPI.java
+++ b/core/src/main/java/com/boydti/fawe/FaweAPI.java
@@ -29,6 +29,8 @@ import org.bukkit.Location;
  */
 public class FaweAPI {
 
+    private FaweAPI() {}
+
     /**
      * Compare two versions
      * @param version

--- a/core/src/main/java/com/boydti/fawe/FaweCache.java
+++ b/core/src/main/java/com/boydti/fawe/FaweCache.java
@@ -20,6 +20,8 @@ public class FaweCache {
     // Faster than java random (since the game just needs to look random)
     public final static PseudoRandom RANDOM = new PseudoRandom();
 
+    private FaweCache() {}
+
     public static BaseBlock getBlock(int id, int data) {
         return CACHE_BLOCK[(id << 4) + data];
     }

--- a/core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -38,6 +38,8 @@ public class Settings {
 
     public static HashMap<String, FaweLimit> limits;
 
+    private Settings() {}
+
     public static FaweLimit getLimit(FawePlayer player) {
         FaweLimit limit = new FaweLimit();
         limit.MAX_CHANGES = 0;

--- a/core/src/main/java/com/boydti/fawe/util/MainUtil.java
+++ b/core/src/main/java/com/boydti/fawe/util/MainUtil.java
@@ -22,6 +22,9 @@ import java.util.Map.Entry;
 import java.util.UUID;
 
 public class MainUtil {
+
+    private MainUtil() {}
+
     /*
      * Generic non plugin related utils
      *  e.g. sending messages

--- a/core/src/main/java/com/boydti/fawe/util/MathMan.java
+++ b/core/src/main/java/com/boydti/fawe/util/MathMan.java
@@ -10,6 +10,8 @@ public class MathMan {
     private static final float INV_ATAN2_DIM_MINUS_1 = 1.0f / (ATAN2_DIM - 1);
     private static final float[] atan2 = new float[ATAN2_COUNT];
 
+    private MathMan() {}
+
     static {
         for (int i = 0; i < ATAN2_DIM; i++) {
             for (int j = 0; j < ATAN2_DIM; j++) {

--- a/core/src/main/java/com/boydti/fawe/util/MemUtil.java
+++ b/core/src/main/java/com/boydti/fawe/util/MemUtil.java
@@ -5,6 +5,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class MemUtil {
 
+    private MemUtil() {}
+
     private static AtomicBoolean memory = new AtomicBoolean(false);
 
     public static boolean isMemoryFree() {

--- a/core/src/main/java/com/boydti/fawe/util/ReflectionUtils.java
+++ b/core/src/main/java/com/boydti/fawe/util/ReflectionUtils.java
@@ -30,6 +30,9 @@ public class ReflectionUtils {
      * boolean value, TRUE if server uses forge or MCPC+
      */
     private static boolean forge = false;
+
+    private ReflectionUtils() {}
+
     /** check server version and class names */
     public static void init() {
         preClassM = "net.minecraft.server";

--- a/core/src/main/java/com/boydti/fawe/util/StringMan.java
+++ b/core/src/main/java/com/boydti/fawe/util/StringMan.java
@@ -9,6 +9,9 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 public class StringMan {
+
+    private StringMan() {}
+
     public static String replaceFromMap(final String string, final Map<String, String> replacements) {
         final StringBuilder sb = new StringBuilder(string);
         int size = string.length();

--- a/core/src/main/java/net/jpountz/lz4/LZ4StreamHelper.java
+++ b/core/src/main/java/net/jpountz/lz4/LZ4StreamHelper.java
@@ -5,7 +5,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public class LZ4StreamHelper {
-   static void writeLength(int length, OutputStream os) throws IOException {
+
+    private LZ4StreamHelper() {}
+
+    static void writeLength(int length, OutputStream os) throws IOException {
         int b1 = ((length & 0xff000000) >> 24);
         int b2 = ((length & 0x00ff0000) >> 16);
         int b3 = ((length & 0x0000ff00) >>  8);

--- a/forge/src/main/java/com/boydti/fawe/forge/SpongeUtil.java
+++ b/forge/src/main/java/com/boydti/fawe/forge/SpongeUtil.java
@@ -17,6 +17,8 @@ public class SpongeUtil {
     private static HashMap<String, Integer> biomeMap;
     public static Map<Integer, BiomeData> biomeData;
 
+    private SpongeUtil() {}
+
     public static void initBiomeCache() {
         try {
             Class<?> clazz = Class.forName("com.sk89q.worldedit.forge.ForgeBiomeRegistry");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava