### PR TITLE
Add option to limit //calc max execute time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
     date = git.head().date.format("yy.MM.dd")
     revision = "-${git.head().abbreviatedId}"
     parents = git.head().parentIds;
-    index = -80;  // Offset to mach CI
+    index = -81;  // Offset to mach CI
     int major, minor, patch;
     major = minor = patch = 0;
     for (;parents != null && !parents.isEmpty();index++) {

--- a/core/src/main/java/com/boydti/fawe/config/Settings.java
+++ b/core/src/main/java/com/boydti/fawe/config/Settings.java
@@ -107,6 +107,8 @@ public class Settings extends Config {
                 " - History on disk or memory will be deleted",
         })
         public int MAX_HISTORY_MB = -1;
+        @Comment("Maximum time in milliseconds //calc can execute")
+        public int MAX_CALC_MS = 50;
         @Comment({
                 "Cinematic block placement:",
                 " - Adds a delay to block placement (ms/block)",
@@ -365,6 +367,7 @@ public class Settings extends Config {
                 limit.MAX_FAILS = Math.max(limit.MAX_FAILS, newLimit.MAX_FAILS != -1 ? newLimit.MAX_FAILS : Integer.MAX_VALUE);
                 limit.MAX_ITERATIONS = Math.max(limit.MAX_ITERATIONS, newLimit.MAX_ITERATIONS != -1 ? newLimit.MAX_ITERATIONS : Integer.MAX_VALUE);
                 limit.MAX_HISTORY = Math.max(limit.MAX_HISTORY, newLimit.MAX_HISTORY_MB != -1 ? newLimit.MAX_HISTORY_MB : Integer.MAX_VALUE);
+                limit.MAX_CALC_MS = Math.max(limit.MAX_CALC_MS, newLimit.MAX_CALC_MS != -1 ? newLimit.MAX_CALC_MS : Integer.MAX_VALUE);
                 limit.INVENTORY_MODE = Math.min(limit.INVENTORY_MODE, newLimit.INVENTORY_MODE);
                 limit.SPEED_REDUCTION = Math.min(limit.SPEED_REDUCTION, newLimit.SPEED_REDUCTION);
                 limit.FAST_PLACEMENT |= newLimit.FAST_PLACEMENT;

--- a/core/src/main/java/com/boydti/fawe/object/FaweLimit.java
+++ b/core/src/main/java/com/boydti/fawe/object/FaweLimit.java
@@ -12,6 +12,7 @@ public class FaweLimit {
     public int MAX_BLOCKSTATES = 0;
     public int MAX_ENTITIES = 0;
     public int MAX_HISTORY = 0;
+    public int MAX_CALC_MS = 0;
     public int INVENTORY_MODE = Integer.MAX_VALUE;
     public int SPEED_REDUCTION = Integer.MAX_VALUE;
     public boolean FAST_PLACEMENT = false;
@@ -55,6 +56,7 @@ public class FaweLimit {
         MAX.MAX_BLOCKSTATES = Integer.MAX_VALUE;
         MAX.MAX_ENTITIES = Integer.MAX_VALUE;
         MAX.MAX_HISTORY = Integer.MAX_VALUE;
+        MAX.MAX_CALC_MS = 50;
         MAX.FAST_PLACEMENT = true;
     }
 


### PR DESCRIPTION
This fixes players abusing //calc by spamming it, causing more
calculation threads be created than destroyed. 