### PR TITLE
Fix problems with handling of schematic loads with extended block IDs

### DIFF
--- a/core/src/main/java/com/boydti/fawe/jnbt/SchematicStreamer.java
+++ b/core/src/main/java/com/boydti/fawe/jnbt/SchematicStreamer.java
@@ -33,9 +33,15 @@ public class SchematicStreamer extends NBTStreamer {
                 setupClipboard(length);
             }
         };
+        NBTStreamReader initializer2 = new NBTStreamReader<Integer, Integer>() {
+            @Override
+            public void run(Integer length, Integer type) {
+                setupClipboard(length*2);
+            }
+        };
         addReader("Schematic.Blocks.?", initializer);
         addReader("Schematic.Data.?", initializer);
-        addReader("Schematic.AddBlocks.?", initializer);
+        addReader("Schematic.AddBlocks.?", initializer2);
         addReader("Schematic.Blocks.#", new ByteReader() {
             @Override
             public void run(int index, int value) {

--- a/core/src/main/java/com/boydti/fawe/object/clipboard/DiskOptimizedClipboard.java
+++ b/core/src/main/java/com/boydti/fawe/object/clipboard/DiskOptimizedClipboard.java
@@ -238,6 +238,8 @@ public class DiskOptimizedClipboard extends FaweClipboard implements Closeable {
             area = width * length;
             volume = width * length * height;
             long size = width * height * length * 2l + HEADER_SIZE + (hasBiomes() ? area : 0);
+            close();
+            this.braf = new RandomAccessFile(file, "rw");
             braf.setLength(size);
             init();
             mbb.putChar(2, (char) width);

--- a/core/src/main/java/com/boydti/fawe/object/clipboard/DiskOptimizedClipboard.java
+++ b/core/src/main/java/com/boydti/fawe/object/clipboard/DiskOptimizedClipboard.java
@@ -521,9 +521,8 @@ public class DiskOptimizedClipboard extends FaweClipboard implements Closeable {
         int index = (HEADER_SIZE) + (i << 1);
         // 00000000 00000000
         // [    id     ]data
-        byte id2 = mbb.get(index + 1);
-        mbb.put(index, (byte) (id >> 4));
-        mbb.put(index + 1, (byte) (((id & 0xFF) << 4) + (id2 & 0xFF)));
+        char combined = mbb.getChar(index);
+        mbb.putChar(index, (char) ((combined & 0xF00F) + (id << 4)));
     }
 
     public void setCombined(int i, int combined) {
@@ -536,7 +535,7 @@ public class DiskOptimizedClipboard extends FaweClipboard implements Closeable {
         // 00000000 00000000
         // [    id     ]data
         char combined = mbb.getChar(index);
-        mbb.putChar(index, (char) ((combined & 0xFFFF) + (add << 12)));
+        mbb.putChar(index, (char) ((combined & 0x0FFF) + (add << 12)));
     }
 
     @Override


### PR DESCRIPTION
This fix is intended to address a couple of problems tied to loading of schematics with extended block IDs (that is, those using the AddBlocks section of the MCEdit Schematics format files):

- The initializer for the AddBlocks length field in SchematicStreamer computes the length of the clipboard incorrectly: since each byte corresponds to 2 blocks, the computed clipboard length is twice the array length
- The order of processing of AddBlocks vs Blocks vs Data isn't deterministic, so the setAdd(), setId() methods in DiskOptmizedClipboard need to preserve all other bits in the combined fields, when used to update
- The use of setDimensions() multiple times by SchematicStreamer, when DiskOptimizedClipboard is used, can result in multiple setLength() calls - this requires the resetting of the MemoryByteBuffer (as is done when setBiome() changes values).  This can happen when the number of blocks N is odd, but AddBlocks is present (which can result in a calculated length of N+1 for its content, but N during handling of Blocks or Data).