### PR TITLE
Fix AddBlock stream to write bytes on odd vs even offsets (off-by-one)

### DIFF
--- a/core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
+++ b/core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
@@ -222,7 +222,7 @@ public class SchematicWriter implements ClipboardWriter {
                     clipboard.IMP.streamIds(new NBTStreamer.ByteReader() {
                         @Override
                         public void run(int index, int byteValue) {
-                            if (write[0] ^= true) {
+                            if (write[0]) {
                                 try {
                                     rawStream.write(((byteValue >> 8) << 4) + (lastAdd[0]));
                                 } catch (IOException e) {
@@ -231,6 +231,7 @@ public class SchematicWriter implements ClipboardWriter {
                             } else {
                                 lastAdd[0] = byteValue >> 8;
                             }
+                            write[0] ^= true;
                         }
                     });
                     if (write[0]) {


### PR DESCRIPTION
The SchematicWriter has an issue with write ordering for AddBlocks data (extended block data).  Specifically, the logic for accumulating the upper nibbles from the block IDs results in an off-by-one style error: the first nibble written is written to the top half of the byte AND causes a flush, the second is accumulated in the bottom half, etc.  This is due to the 'if (write[0] ^= true)' operation matching on the new value for write, versus the previous value.  Moving the update to after the conditional corrects the behavior - resulting in the accumulate low nibble, write-high-with-accumulated-low behavior that is intended.  
The existing problem can be demonstrated by loading a schematic with extended block ids (//schem load XXX), then saving it (//schem save YYY), and then loading the newly saved version (//schem load YYY) - where XXX results in proper block IDs, YYY will not.  The corrected code has been verified in this same manner, and corrects the behavior.