### PR TITLE
Fix for double chest delete exception

### DIFF
--- a/forge111/src/main/java/com/boydti/fawe/forge/v111/ForgeChunk_All.java
+++ b/forge111/src/main/java/com/boydti/fawe/forge/v111/ForgeChunk_All.java
@@ -273,8 +273,8 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                     int k = FaweCache.CACHE_J[ly][lz][lx];
                     if (array[k] != 0) {
                         synchronized (ForgeChunk_All.class) {
-                            tile.getValue().invalidate();
                             iterator.remove();
+                            tile.getValue().invalidate();
                         }
                     }
                 }

--- a/forge112/src/main/java/com/boydti/fawe/forge/v112/ForgeChunk_All.java
+++ b/forge112/src/main/java/com/boydti/fawe/forge/v112/ForgeChunk_All.java
@@ -273,8 +273,8 @@ public class ForgeChunk_All extends CharFaweChunk<Chunk, ForgeQueue_All> {
                     int k = FaweCache.CACHE_J[ly][lz][lx];
                     if (array[k] != 0) {
                         synchronized (ForgeChunk_All.class) {
-                            tile.getValue().invalidate();
                             iterator.remove();
+                            tile.getValue().invalidate();
                         }
                     }
                 }

--- a/sponge/src/main/java/com/boydti/fawe/sponge/v1_12/SpongeChunk_1_12.java
+++ b/sponge/src/main/java/com/boydti/fawe/sponge/v1_12/SpongeChunk_1_12.java
@@ -273,8 +273,8 @@ public class SpongeChunk_1_12 extends CharFaweChunk<Chunk, SpongeQueue_1_12> {
                     int k = FaweCache.CACHE_J[ly][lz][lx];
                     if (array[k] != 0) {
                         synchronized (SpongeChunk_1_12.class) {
-                            tile.getValue().invalidate();
                             iterator.remove();
+                            tile.getValue().invalidate();
                         }
                     }
                 }

--- a/sponge111/src/main/java/com/boydti/fawe/sponge/v1_11/SpongeChunk_1_11.java
+++ b/sponge111/src/main/java/com/boydti/fawe/sponge/v1_11/SpongeChunk_1_11.java
@@ -273,8 +273,8 @@ public class SpongeChunk_1_11 extends CharFaweChunk<Chunk, SpongeQueue_1_11> {
                     int k = FaweCache.CACHE_J[ly][lz][lx];
                     if (array[k] != 0) {
                         synchronized (SpongeChunk_1_11.class) {
-                            tile.getValue().invalidate();
                             iterator.remove();
+                            tile.getValue().invalidate();
                         }
                     }
                 }


### PR DESCRIPTION
Selecting a region containing a double chest, and replacing the blocks such that the double chest is replaced, results in a ConcurrentModificationException due to processing within the invalidate() method for the Tile Entity for the chest modifying the chunk's tile entity list under the iterator.  Altering the order of operations to remove the element from the iterator before calling invalidate() prevents the issue and seems to result in normal operation.  Fix covers forge 1.11.2 and 1.12, as well as Sponge 1.11.2 and 1.12 - the problem may exist in other versions, but I'm not set up to verify this.