### PR TITLE
Fix: Added double slash on cuboid selection

### DIFF
--- a/core/src/main/java/com/sk89q/worldedit/regions/selector/CuboidRegionSelector.java
+++ b/core/src/main/java/com/sk89q/worldedit/regions/selector/CuboidRegionSelector.java
@@ -161,7 +161,7 @@ public class CuboidRegionSelector extends com.sk89q.worldedit.regions.CuboidRegi
         } else {
             msg = BBC.SELECTOR_POS.m(1, position1, "");
         }
-        String cmd = Commands.getAlias(SelectionCommands.class, "/pos1") + " " + pos.getBlockX() + "," + pos.getBlockY() + "," + pos.getBlockZ();
+        String cmd = "/" + Commands.getAlias(SelectionCommands.class, "/pos1") + " " + pos.getBlockX() + "," + pos.getBlockY() + "," + pos.getBlockZ();
         msg.suggestTip(cmd).send(player);
 
         session.dispatchCUIEvent(player, new SelectionPointEvent(0, pos, getArea()));
@@ -179,7 +179,7 @@ public class CuboidRegionSelector extends com.sk89q.worldedit.regions.CuboidRegi
         } else {
             msg = BBC.SELECTOR_POS.m(2, position2, "");
         }
-        String cmd = Commands.getAlias(SelectionCommands.class, "/pos2") + " " + pos.getBlockX() + "," + pos.getBlockY() + "," + pos.getBlockZ();
+        String cmd = "/" + Commands.getAlias(SelectionCommands.class, "/pos2") + " " + pos.getBlockX() + "," + pos.getBlockY() + "," + pos.getBlockZ();
         msg.suggestTip(cmd).send(player);
 
         session.dispatchCUIEvent(player, new SelectionPointEvent(1, pos, getArea()));


### PR DESCRIPTION
Because when you select a position and click on the message you need to manually add a other slash before the command