### PR TITLE
Create block pattern (Fixes #810)

### DIFF
--- a/core/src/main/java/com/sk89q/worldedit/EditSession.java
+++ b/core/src/main/java/com/sk89q/worldedit/EditSession.java
@@ -1729,7 +1729,7 @@ public class EditSession extends AbstractWorld implements HasFaweQueue, Lighting
 //            return changes = region.getArea();
 //        }
         // TODO fast replace
-        return this.replaceBlocks(region, filter, (replacement));
+        return this.replaceBlocks(region, filter, new BlockPattern(replacement));
     }
 
 


### PR DESCRIPTION
Previously `EditSession#replaceBlocks(Region, Set<BaseBlock>, BaseBlock)` called itself. This re-adds the new BlockPattern creation which for whatever reason was removed in d7d897d1 and fixes the resulting [stack overflow](https://hastebin.com/juricudofe).