### PR TITLE
fixed //overlay command 

### DIFF
--- a/core/src/main/java/com/boydti/fawe/object/function/SurfaceRegionFunction.java
+++ b/core/src/main/java/com/boydti/fawe/object/function/SurfaceRegionFunction.java
@@ -27,7 +27,7 @@ public class SurfaceRegionFunction implements FlatRegionFunction {
     public boolean apply(Vector2D position) throws WorldEditException {
         int x = position.getBlockX();
         int z = position.getBlockZ();
-        int layer = extent.getNearestSurfaceTerrainBlock(x, z, lastY, minY, maxY);
+        int layer = extent.getNearestSurfaceTerrainBlock(x, z, lastY, minY, maxY, false);
         if (layer != -1) {
             lastY = layer;
             return function.apply(mutable.setComponents(x, layer, z));

--- a/core/src/main/java/com/sk89q/worldedit/extent/Extent.java
+++ b/core/src/main/java/com/sk89q/worldedit/extent/Extent.java
@@ -122,11 +122,19 @@ public interface Extent extends InputExtent, OutputExtent {
         return (state ? minY : maxY) << 4;
     }
 
+    public default int getNearestSurfaceTerrainBlock(int x, int z, int y, int minY, int maxY, boolean ignoreAir) {
+        return getNearestSurfaceTerrainBlock(x, z, y, minY, maxY, minY, maxY, ignoreAir);
+    }
+
     public default int getNearestSurfaceTerrainBlock(int x, int z, int y, int minY, int maxY) {
         return getNearestSurfaceTerrainBlock(x, z, y, minY, maxY, minY, maxY);
     }
 
     public default int getNearestSurfaceTerrainBlock(int x, int z, int y, int minY, int maxY, int failedMin, int failedMax) {
+        return getNearestSurfaceTerrainBlock(x, z, y, minY, maxY, failedMin, failedMax, true);
+    }
+
+    public default int getNearestSurfaceTerrainBlock(int x, int z, int y, int minY, int maxY, int failedMin, int failedMax, boolean ignoreAir) {
         y = Math.max(minY, Math.min(maxY, y));
         int clearanceAbove = maxY - y;
         int clearanceBelow = y - minY;
@@ -155,7 +163,12 @@ public interface Extent extends InputExtent, OutputExtent {
                 }
             }
         }
-        return state ? failedMin : failedMax;
+        int result = state ? failedMin : failedMax;
+        if(result > 0 && !ignoreAir) {
+            block = getLazyBlock(x, result, z);
+            return block.isAir() ? -1 : result;
+        }
+        return result;
     }
 
     default public void addCaves(Region region) throws WorldEditException {


### PR DESCRIPTION
I fixed the problem with //overlay where blocks where placed upon air if it was the bottom layer. The old functionality still exists due to the `boolean ignoreAir` parameter.