### PR TITLE
Fix of issue #1123 

### DIFF
--- a/core/src/main/java/com/boydti/fawe/Fawe.java
+++ b/core/src/main/java/com/boydti/fawe/Fawe.java
@@ -201,11 +201,15 @@ public class Fawe {
      * @param s
      */
     public static void debug(Object s) {
-        Actor actor = Request.request().getActor();
-        if (actor != null && actor.isPlayer()) {
-            actor.print(BBC.color(BBC.PREFIX.original() + " " + s));
-            return;
+        if (INSTANCE != null) // Fix of issue 1123 - Didn't check the whole code, but WorldEdit should be loaded when an INSTANCE of FAWE is set. (Since this is a core class, I didn't use the Bukkit API)
+        {
+            Actor actor = Request.request().getActor();
+            if (actor != null && actor.isPlayer()) {
+                actor.print(BBC.color(BBC.PREFIX.original() + " " + s));
+                return;
+            }
         }
+
         debugPlain(BBC.PREFIX.original() + " " + s);
     }
 


### PR DESCRIPTION
Fix of issue #1123 
Didn't check the whole code, but WorldEdit should be loaded when an INSTANCE of FAWE is set. (Since this is a core class, I didn't use the Bukkit API)

Tested after change:
- Starting server without WorldEdit - Working
- Starting server with AsyncWorldEdit - Working 