### PR TITLE
Fix height brush.

### DIFF
--- a/core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
+++ b/core/src/main/java/com/sk89q/worldedit/command/BrushCommands.java
@@ -745,7 +745,7 @@ public class BrushCommands extends BrushProcessor {
 
     private BrushSettings terrainBrush(Player player, LocalSession session, Expression radius, String image, int rotation, double yscale, boolean flat, boolean randomRotate, boolean layers, boolean smooth, ScalableHeightMap.Shape shape, CommandContext context) throws WorldEditException, FileNotFoundException, ParameterException {
         checkMaxBrushRadius(radius);
-        InputStream stream = image == null ? null : getHeightmapStream(image);
+        InputStream stream = (image == null || image.equalsIgnoreCase("null") || image.equalsIgnoreCase("#clipboard")) ? null : getHeightmapStream(image);
         HeightBrush brush;
         if (flat) {
             try {


### PR DESCRIPTION
Hey there! This just changes checking for _"null"_, the string, instead of _null_, which cannot be typed into Minecraft chat. It also additionally checks for _#clipboard_.

You can see that this is not an addition, rather a simple fix to [issue 1162](https://github.com/boy0001/FastAsyncWorldedit/issues/1162).

You can see that this should be normal functionality from the command help in Minecraft by doing /br height ![screen shot 2018-11-07 at 11 27 22 pm](https://user-images.githubusercontent.com/32250137/48177840-e956c980-e2e4-11e8-9493-d85264066362.png)

The code was completely done by IronApollo, one of the FAWE developers. I just double checked it by building FAWE again, and it does fix it, and submitting a pull request.

Thanks!