### PR TITLE
Fix lazy SchematicWriter with WorldCopyClipboard containing AddBlocks

### DIFF
--- a/core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
+++ b/core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java
@@ -197,9 +197,7 @@ public class SchematicWriter implements ClipboardWriter {
                                     int add = id >> 8;
                                     if (!hasAdd) {
                                         hasAdd = true;
-                                        for (int i = 0; i < index >> 1; i++) {
-                                            addOut.write(new byte[index >> 1]);
-                                        }
+                                        addOut.write(new byte[index >> 1]);
                                     }
                                     if ((index & 1) == 1) {
                                         addOut.write(addAcc[0] + (add << 4));


### PR DESCRIPTION
Current implementation is invalid in this case (and will generate gigantic files). See the non-lazy implementation: https://github.com/boy0001/FastAsyncWorldedit/blob/master/core/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicWriter.java#L99